### PR TITLE
Increase URL length

### DIFF
--- a/fields/url-v1.json
+++ b/fields/url-v1.json
@@ -2,7 +2,7 @@
   "title": "URL",
   "description": "The URL of the entity or item",
   "type": "string",
-  "maxLength": 100,
+  "maxLength": 2000,
   "pattern": "https?://",
   "metadata": {
     "creator": {


### PR DESCRIPTION
Increase to 2000 as suggested in [this Stack Overflow post](https://stackoverflow.com/questions/29458445/what-is-a-safe-maximum-length-a-segment-in-a-url-path-should-be/33733386#:~:text=In%20short,remain%20under%20approximately%202000%20characters.).