### PR TITLE
Enforce snake_cased property names

### DIFF
--- a/schemas/default-v1.json
+++ b/schemas/default-v1.json
@@ -1,9 +1,12 @@
 {
-  "$schema": "https://json-schema.org/draft-04/schema#",
+  "$schema": "https://json-schema.org/draft-06/schema#",
   "id": "https://cdn.murmurations.network/schemas/default-v1.json",
   "title": "Default Schema",
   "description": "The default schema for initial validation of a profile by the index.",
   "type": "object",
+  "propertyNames": {
+    "pattern": "^[a-z0-9_]*$"
+  },
   "properties": {
     "linked_schemas": {
       "$ref": "../fields/linked_schemas-v1.json"


### PR DESCRIPTION
We should enforce snake_casing of property names with the `propertyNames` option introduced in JSON Schema Draft 6.

I don't mind going to Draft 6 since our current set of tools works with it. 

See the Telegram chat with Matt about why it is worth setting this up.
