### PR TITLE
Solidarity economy initiatives schema: draft

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# Cross-platform formatting config
+# See https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,json,yml,yaml}]
+charset = utf-8
+indent_style = space
+indent_size = 2
+

--- a/schemas/solidarity_economy_initiatives-v0.1.0.json
+++ b/schemas/solidarity_economy_initiatives-v0.1.0.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft-04/schema#",
+  "id": "https://cdn.murmurations.network/schemas/solidarity_economy_initiatives-v0.1.0.json",
+  "title": "Solidarity Economy Initiatives",
+  "description": "Describes an initiative in the Solidarity Economy. FIXME and WARNING: this is experimental!",
+  "type": "object",
+  "propertyNames": {
+    "pattern": "^[a-z0-9_]*$"
+  },
+  "properties": {
+    "linked_schemas": {
+      "$ref": "../fields/linked_schemas-v1.json"
+    },
+    "ld_uri": {
+      "$ref": "../fields/url-v1.json"
+    },
+    "name": {
+      "$ref": "../fields/name-v1.json"
+    },
+    "description": {
+      "$ref": "../fields/description-v1.json"
+    },
+    "website": {
+      "$ref": "../fields/url-v1.json"
+    },
+    "location": {
+      "$ref": "../fields/location-v1.json"
+    },
+    "geolocation": {
+      "$ref": "../fields/geolocation-v1.json"
+    },
+    "org_type_tags": {
+      "$ref": "../fields/org_type_tags-v1.json"
+    }
+  },
+  "required": ["linked_schemas", "name", "ld_uri"],
+  "metadata": {
+    "creator": {
+      "name": "Solidarity Economy Association",
+      "url": "https://www.solidarityeconomy.coop/"
+    },
+    "schema": {
+      "name": "solidarity_economy_initiatives-v0.1.0",
+      "version": "0.1.0",
+      "url": "https://github.com/SolidarityEconomyAssociation/MurmurationsLibrary/wiki/solidarity_economy_initiatives-v0.1.0",
+      "purpose": "A map of organisations within the solidarity economy."
+    }
+  }
+}


### PR DESCRIPTION
This is a first draft, and I've written some code to generate JSON files with matching schemas, example published here:

https://dev.data.solidarityeconomy.coop/sea-lod/oxford/65.murm.json

I've only used existing fields for now. We might look at new field types when this is working otherwise, as well as annotating it with json-ld tags.

But the next thing is to see if we can get Murmurations consuming the 170-odd initiatives in the Solidarity Oxford dataset, on URLs like https://dev.lod.coop/sea-lod/oxford/65.murm.json (redirection rules need to be adjusted first).



