### PR TITLE
Adding non-versioned (or "soft versioned") fields

### DIFF
--- a/fields/address.json
+++ b/fields/address.json
@@ -1,0 +1,20 @@
+{
+  "title": "Address",
+  "description": "The physical address of the entity in a single text field",
+  "type": "string",
+  "minLength": 1,
+  "maxLength": 2000,
+  "metadata": {
+    "creator": {
+      "name": "Murmurations Network",
+      "url": "https://murmurations.network"
+    },
+    "field": {
+      "name": "address",
+      "version": "0.0.1"
+    },
+    "context": [
+      "https://schema.org/address"
+    ]
+  }
+}

--- a/fields/country_iso_3166-1.json
+++ b/fields/country_iso_3166-1.json
@@ -260,7 +260,7 @@
     },
     "field": {
       "name": "country_iso_3166-1",
-      "version": 1
+      "version": "0.0.1"
     },
     "context": [
       "https://en.wikipedia.org/wiki/ISO_3166-1"

--- a/fields/country_name.json
+++ b/fields/country_name.json
@@ -9,7 +9,7 @@
     },
     "field": {
       "name": "country_name",
-      "version": 1
+      "version": "0.0.1"
     },
     "context": [
       "https://schema.org/Country"

--- a/fields/description.json
+++ b/fields/description.json
@@ -1,0 +1,18 @@
+{
+  "title": "Description",
+  "description": "A description of the item, entity, organization, project, etc.",
+  "type": "string",
+  "minLength": 1,
+  "metadata": {
+    "creator": {
+      "name": "Murmurations Network",
+      "url": "https://murmurations.network"
+    },
+    "field": {
+      "name": "description",
+      "version": "0.0.1"
+    },
+    "context": ["http://schema.org/description"],
+    "purpose": "The Description field can be used to provided a description of the item, entity, organization, project, etc. We have chosen not to add a maximum length but aggregators will snip the first ~160 characters of this field to provide a summary in directory listings or maps, so make sure the first sentence provides a good overview of the entity you are describing."
+  }
+}

--- a/fields/email.json
+++ b/fields/email.json
@@ -1,0 +1,18 @@
+{
+  "title": "Email address",
+  "description": "An email address",
+  "type": "string",
+  "metadata": {
+    "creator": {
+      "name": "Murmurations Network",
+      "url": "https://murmurations.network"
+    },
+    "field": {
+      "name": "email",
+      "version": "0.0.1"
+    },
+    "context": [
+      "https://schema.org/email"
+    ]
+  }
+}

--- a/fields/geographic_scope.json
+++ b/fields/geographic_scope.json
@@ -1,0 +1,16 @@
+{
+  "title": "Geographic Scope",
+  "description": "The geographic scope of this entity",
+  "type": "string",
+  "enum": ["local", "regional", "national", "international"],
+  "metadata": {
+    "creator": {
+      "name": "Murmurations Network",
+      "url": "https://murmurations.network"
+    },
+    "field": {
+      "name": "geographic_scope",
+      "version": "0.0.1"
+    }
+  }
+}

--- a/fields/image.json
+++ b/fields/image.json
@@ -1,0 +1,16 @@
+{
+  "title": "Image",
+  "description": "The URL of a logo or other image for the entity",
+  "type": "string",
+  "metadata": {
+    "creator": {
+      "name": "Murmurations Network",
+      "url": "https://murmurations.network"
+    },
+    "field": {
+      "name": "image",
+      "version": "0.0.1"
+    },
+    "context": ["https://schema.org/image"]
+  }
+}

--- a/fields/latitude.json
+++ b/fields/latitude.json
@@ -11,7 +11,7 @@
     },
     "field": {
       "name": "latitude",
-      "version": 1
+      "version": "0.0.1"
     },
     "context": [
       "https://schema.org/latitude"

--- a/fields/linked_schemas.json
+++ b/fields/linked_schemas.json
@@ -1,0 +1,22 @@
+{
+  "title": "Linked Schemas",
+  "description": "The schemas against which the profile must be validated (must be alphanumeric with a dash(-) and/or underscore(_), e.g., demo_schema-v1",
+  "type": "array",
+  "items": {
+    "type": "string",
+    "pattern": "[A-Za-z0-9-._]{4,100}$"
+  },
+  "minItems": 1,
+  "uniqueItems": true,
+  "metadata": {
+    "creator": {
+      "name": "Murmurations Network",
+      "url": "https://murmurations.network"
+    },
+    "field": {
+      "name": "linked_schemas",
+      "version": "0.0.1"
+    },
+    "context": ["https://murmurations.network/fields/linked_schemas"]
+  }
+}

--- a/fields/locality.json
+++ b/fields/locality.json
@@ -9,7 +9,7 @@
     },
     "field": {
       "name": "locality",
-      "version": 1
+      "version": "0.0.1"
     },
     "context": [
       "https://schema.org/addressLocality"

--- a/fields/longitude.json
+++ b/fields/longitude.json
@@ -11,7 +11,7 @@
     },
     "field": {
       "name": "longitude",
-      "version": 1
+      "version": "0.0.1"
     },
     "context": [
       "https://schema.org/longitude"

--- a/fields/mission.json
+++ b/fields/mission.json
@@ -1,0 +1,16 @@
+{
+  "title": "Mission Statement",
+  "description": "A short statement of why the entity exists, what its overall goal is: what kind of product or service it provides, its primary customers or market, and its geographical region of operation.",
+  "type": "string",
+  "metadata": {
+    "creator": {
+      "name": "Murmurations Network",
+      "url": "https://murmurations.network"
+    },
+    "field": {
+      "name": "mission",
+      "version": "0.0.1"
+    },
+    "context": ["https://en.wikipedia.org/wiki/Mission_statement"]
+  }
+}

--- a/fields/name.json
+++ b/fields/name.json
@@ -1,0 +1,16 @@
+{
+  "title": "Name",
+  "description": "The name of the entity, organization, project, etc.",
+  "type": "string",
+  "metadata": {
+    "creator": {
+      "name": "Murmurations Network",
+      "url": "https://murmurations.network"
+    },
+    "field": {
+      "name": "name",
+      "version": "0.0.1"
+    },
+    "context": ["https://schema.org/name"]
+  }
+}

--- a/fields/primary_url.json
+++ b/fields/primary_url.json
@@ -1,5 +1,5 @@
 {
-  "title": "URL",
+  "title": "Primary URL",
   "description": "The primary URL of the entity or item",
   "type": "string",
   "maxLength": 2000,
@@ -10,7 +10,7 @@
       "url": "https://murmurations.network"
     },
     "field": {
-      "name": "url",
+      "name": "primary_url",
       "version": "0.0.1"
     },
     "context": ["https://schema.org/url"]

--- a/fields/primary_url.json
+++ b/fields/primary_url.json
@@ -1,0 +1,18 @@
+{
+  "title": "URL",
+  "description": "The primary URL of the entity or item",
+  "type": "string",
+  "maxLength": 2000,
+  "pattern": "https?://",
+  "metadata": {
+    "creator": {
+      "name": "Murmurations Network",
+      "url": "https://murmurations.network"
+    },
+    "field": {
+      "name": "url",
+      "version": "0.0.1"
+    },
+    "context": ["https://schema.org/url"]
+  }
+}

--- a/fields/region.json
+++ b/fields/region.json
@@ -9,7 +9,7 @@
     },
     "field": {
       "name": "region",
-      "version": 1
+      "version": "0.0.1"
     },
     "context": [
       "https://schema.org/addressRegion"

--- a/fields/rss.json
+++ b/fields/rss.json
@@ -1,0 +1,17 @@
+{
+  "title": "RSS feed",
+  "description": "The URL for an RSS feed",
+  "type": "string",
+  "pattern": "https?://",
+  "metadata": {
+    "creator": {
+      "name": "Murmurations Network",
+      "url": "https://murmurations.network"
+    },
+    "field": {
+      "name": "rss",
+      "version": "0.0.1"
+    },
+    "context": ["https://en.wikipedia.org/wiki/RSS"]
+  }
+}

--- a/fields/tags.json
+++ b/fields/tags.json
@@ -1,0 +1,20 @@
+{
+  "title": "Tags",
+  "description": "Keywords relevant to this entity or its activities",
+  "type": "array",
+  "items": {
+    "type": "string"
+  },
+  "uniqueItems": true,
+  "metadata": {
+    "creator": {
+      "name": "Murmurations Network",
+      "url": "https://murmurations.network"
+    },
+    "field": {
+      "name": "tags",
+      "version": "0.0.1"
+    },
+    "context": ["https://schema.org/keywords"]
+  }
+}

--- a/fields/urls.json
+++ b/fields/urls.json
@@ -8,12 +8,14 @@
       "name": {
         "title": "URL Name",
         "description": "The name of what this URL is for (e.g., the name of the social media provider, website, etc.)",
-        "type": "string",
-        "minLength": 1,
-        "maxLength": 100
+        "type": "string"
       },
       "url": {
-        "$ref": "url.json"
+        "title": "URL",
+        "description": "The URL of the entity or item",
+        "type": "string",
+        "maxLength": 2000,
+        "pattern": "https?://"
       }
     },
     "required": ["name", "url"]

--- a/fields/urls.json
+++ b/fields/urls.json
@@ -1,0 +1,33 @@
+{
+  "title": "Website Addresses/URLs",
+  "description": "URLs for website(s), social media, etc.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "name": {
+        "title": "URL Name",
+        "description": "The name of what this URL is for (e.g., the name of the social media provider, website, etc.)",
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 100
+      },
+      "url": {
+        "$ref": "url.json"
+      }
+    },
+    "required": ["name", "url"]
+  },
+  "uniqueItems": true,
+  "metadata": {
+    "creator": {
+      "name": "Murmurations Network",
+      "url": "https://murmurations.network"
+    },
+    "field": {
+      "name": "urls",
+      "version": "0.0.1"
+    },
+    "context": ["https://schema.org/url"]
+  }
+}


### PR DESCRIPTION
Added copies of existing fields that don't include a version number in the field name or file name (still including a semver number in the field metatdata), per considerations posted in the discussion [here.](https://github.com/MurmurationsNetwork/MurmurationsProtocol/discussions/35).

Other changes:
- Renamed `url` field to `primary_url` in new field file to indicate its importance in identifying nodes
- Renamed `area_served` to `geographic_scope` to avoid misusing a schema.org designated field name
- `image` is now used for a single image URL, rather than an array of objects
- Added generic `tags` field (replaces earlier `keywords` field)