### PR TITLE
Try geopoint as string

### DIFF
--- a/schemas/karte_von_morgen-v1.0.0.json
+++ b/schemas/karte_von_morgen-v1.0.0.json
@@ -23,6 +23,10 @@
     "longitude": {
       "$ref": "../fields/longitude.json"
     },
+    "geolocation": {
+      "type": "string",
+      "value": "lat,lon"
+    },
     "address": {
       "$ref": "../fields/address.json"
     },


### PR DESCRIPTION
Looking for a clean solution to handle the standard formatting of geopoints:  
https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-point.html